### PR TITLE
Feature/Update Subscribers

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ $resubscribe = false;
 craft()->oneCampaignMonitor_subscribers->add($list_id, $email, $name, $customFields, $resubscribe);
 ```
 
-Update a user in a list:
+Update a subscriber in a list:
 
 ```
 $list_id = '123';
@@ -133,6 +133,16 @@ $name = 'Steve';
 $customFields = ['city': 'New York'];
 $resubscribe = true;
 craft()->oneCampaignMonitor_subscribers->update($list_id, $email, $name, $customFields, $resubscribe);
+```
+
+Determine if a subscriber exists in a list:
+
+```
+$list_id = '123';
+$email = 'email@email.com';
+if (craft()->oneCampaignMonitor_subscribers->exists($list_id, $email)) {
+  // subscriber exists
+}
 ```
 
 ### Checking if the user has subscribed to a list

--- a/README.md
+++ b/README.md
@@ -124,6 +124,17 @@ $resubscribe = false;
 craft()->oneCampaignMonitor_subscribers->add($list_id, $email, $name, $customFields, $resubscribe);
 ```
 
+Update a user in a list:
+
+```
+$list_id = '123';
+$email = 'email@email.com';
+$name = 'Steve';
+$customFields = ['city': 'New York'];
+$resubscribe = true;
+craft()->oneCampaignMonitor_subscribers->update($list_id, $email, $name, $customFields, $resubscribe);
+```
+
 ### Checking if the user has subscribed to a list
 
 You can check in a template if the current user (by session) has already subscribed to a list:

--- a/consolecommands/OneCampaignMonitorSubscribersCommand.php
+++ b/consolecommands/OneCampaignMonitorSubscribersCommand.php
@@ -4,14 +4,14 @@ namespace Craft;
 class OneCampaignMonitorSubscribersCommand extends BaseCommand {
 
     /**
-     * Adds a user to a list
+     * Adds a subscriber to a list
      * Usage:
      *   php ./craft/app/etc/console/yiic onecampaignmonitorsubscribers add \
      *       --listId="asdf..." \
      *       --email="test@example.com" \
      *       --name="Mr. Test" \
      *       --resubscribe=1 \
-     *       --customFields='[{"Key":"Subscriptions","Value":"FN-SUB36-Renewal"}]' \
+     *       --customFields='[{"Key":"City","Value":"Chicago"}]' \
      */
     public function actionAdd($listId, $email, $name=null, $customFields='[]', $resubscribe=true) {
         $customFields = $this->_decodeCustomFields($customFields);
@@ -19,19 +19,34 @@ class OneCampaignMonitorSubscribersCommand extends BaseCommand {
     }
 
     /**
-     * Looks through all orders and adds users to User Groups based on their subscription items
+     * Updates a subscriber in a list
      * Usage:
      *   php ./craft/app/etc/console/yiic onecampaignmonitorsubscribers update \
      *       --listId="asdf..." \
      *       --email="test@example.com" \
      *       --name="Joan Doe" \
      *       --resubscribe=0 \
-     *       --customFields='[{"Key":"Subscriptions","Value":"FN-SUB36-Renewal"}]' \
+     *       --customFields='[{"Key":"City","Value":"New York"}]' \
      *       --merge=1
      */
     public function actionUpdate($listId, $email, $name=null, $customFields='[]', $resubscribe=false, $merge=true) {
         $customFields = $this->_decodeCustomFields($customFields);
         craft()->oneCampaignMonitor_subscribers->update($listId, $email, $name, $customFields, $resubscribe ? true : false, $merge  ? true : false);
+    }
+
+    /**
+     * Determines is an email exists in a list
+     * Usage:
+     *   php ./craft/app/etc/console/yiic onecampaignmonitorsubscribers update \
+     *       --listId="asdf..." \
+     *       --email="test@example.com"
+     */
+    public function actionExists($listId, $email) {
+        if (craft()->oneCampaignMonitor_subscribers->exists($listId, $email)) {
+            OneCampaignMonitorPlugin::log('Subscriber exists in this list.', LogLevel::Info);
+        } else {
+            OneCampaignMonitorPlugin::log('Subscriber does not exist in the list.', LogLevel::Info);
+        }
     }
 
     /**

--- a/consolecommands/OneCampaignMonitorSubscribersCommand.php
+++ b/consolecommands/OneCampaignMonitorSubscribersCommand.php
@@ -1,0 +1,52 @@
+<?php
+namespace Craft;
+
+class OneCampaignMonitorSubscribersCommand extends BaseCommand {
+
+    /**
+     * Adds a user to a list
+     * Usage:
+     *   php ./craft/app/etc/console/yiic onecampaignmonitorsubscribers add \
+     *       --listId="asdf..." \
+     *       --email="test@example.com" \
+     *       --name="Mr. Test" \
+     *       --resubscribe=1 \
+     *       --customFields='[{"Key":"Subscriptions","Value":"FN-SUB36-Renewal"}]' \
+     */
+    public function actionAdd($listId, $email, $name=null, $customFields='[]', $resubscribe=true) {
+        $customFields = $this->_decodeCustomFields($customFields);
+        craft()->oneCampaignMonitor_subscribers->add($listId, $email, $name, $customFields, $resubscribe ? true : false);
+    }
+
+    /**
+     * Looks through all orders and adds users to User Groups based on their subscription items
+     * Usage:
+     *   php ./craft/app/etc/console/yiic onecampaignmonitorsubscribers update \
+     *       --listId="asdf..." \
+     *       --email="test@example.com" \
+     *       --name="Joan Doe" \
+     *       --resubscribe=0 \
+     *       --customFields='[{"Key":"Subscriptions","Value":"FN-SUB36-Renewal"}]' \
+     *       --merge=1
+     */
+    public function actionUpdate($listId, $email, $name=null, $customFields='[]', $resubscribe=false, $merge=true) {
+        $customFields = $this->_decodeCustomFields($customFields);
+        craft()->oneCampaignMonitor_subscribers->update($listId, $email, $name, $customFields, $resubscribe ? true : false, $merge  ? true : false);
+    }
+
+    /**
+     * Decodes the customFields input option
+     * @param  String $customFields JSON array of key/value objects
+     * @return Array
+     */
+    private function _decodeCustomFields($customFields) {
+        $decoded = json_decode($customFields, true);
+
+        if (!is_array($decoded)) {
+            throw new Exception('customFields must be specified as a JSON array of key/value objects');
+        }
+
+        return $decoded;
+    }
+
+}

--- a/services/OneCampaignMonitor_BaseService.php
+++ b/services/OneCampaignMonitor_BaseService.php
@@ -18,7 +18,11 @@ class OneCampaignMonitor_BaseService extends BaseApplicationComponent {
     protected function parseCustomFields($fields) {
         $data = array();
         foreach ($fields as $key => $value) {
-            $data[] = ['Key' => $key, 'Value' => $value];
+            if (is_array($value) && array_key_exists('Key', $value) && array_key_exists('Value', $value) ) {
+                $data[] = $value;
+            } else {
+                $data[] = ['Key' => $key, 'Value' => $value];
+            }
         }
         return $data;
     }

--- a/services/OneCampaignMonitor_SubscribersService.php
+++ b/services/OneCampaignMonitor_SubscribersService.php
@@ -5,6 +5,16 @@ require_once CRAFT_BASE_PATH . '../vendor/campaignmonitor/createsend-php/csrest_
 
 class OneCampaignMonitor_SubscribersService extends OneCampaignMonitor_BaseService {
 
+    /**
+     * Adds a subscriber to a list
+     * @param  $listId
+     * @param  $email
+     * @param  $name
+     * @param  $customFields
+     * @param  $resubscribe
+     * @param  $merge
+     * @throws Exception
+     */
     public function add($listId, $email, $name=null, $customFields=array(), $resubscribe=true) {
         if (!$listId) {
             throw new Exception('List ID is required');
@@ -29,4 +39,71 @@ class OneCampaignMonitor_SubscribersService extends OneCampaignMonitor_BaseServi
         return true;
     }
 
+    /**
+     * Updates a subscriber in a list
+     * @param  $listId
+     * @param  $email
+     * @param  $name
+     * @param  $customFields
+     * @param  Boolean $resubscribe Re-activate an existing user if they have been deactivated
+     * @param  Boolean $mergeMultiFields Multi-Valued Select Many fields will be merged together instead of overwritten
+     * @throws Exception
+     */
+    public function update($listId, $email, $name=null, $customFields=array(), $resubscribe=false, $mergeMultiFields=false) {
+        if (!$listId) {
+            throw new Exception('List ID is required');
+        }
+        if (!$email) {
+            throw new Exception('Please provide a valid email address');
+        }
+
+        $connection = new \CS_REST_Subscribers($listId, $this->auth());
+        
+        $subscriber = [
+            'Resubscribe' => $resubscribe
+        ];
+
+        if (!empty($name)) {
+            $subscriber['Name'] = $name;
+        }
+
+        $subscriber['CustomFields'] = $this->parseCustomFields($customFields);
+
+        if ($mergeMultiFields) {
+            $result = $connection->get($email);
+            $existingSubscriber = $result->response;
+
+            // Count the number of occurances of custom field to know 
+            // which is a Multi-Valued Select Many field
+            $fieldOccurances = [];
+            foreach ($existingSubscriber->CustomFields as $existingField) {
+                if (array_key_exists($existingField->Key, $fieldOccurances)) {
+                    $fieldOccurances[$existingField->Key]++;
+                } else {
+                    $fieldOccurances[$existingField->Key] = 1;
+                }
+            }
+
+            // For any Multi-Valued Select Many field, make sure to append the 
+            // existing field values
+            foreach($fieldOccurances as $key => $value) {
+                if ($value > 1) {
+                    foreach($existingSubscriber->CustomFields as $existingField) {
+                        if ($existingField->Key == $key) {
+                            $subscriber['CustomFields'][] = $existingField;
+                        }
+                    }
+                }
+            }
+        } else {
+            $subscriber['CustomFields'] = $parsedCustomFields;
+        }
+        
+        $result = $connection->update($email, $subscriber);
+
+        $error = null;
+        if (!$this->response($result, $error)) {
+            throw new Exception($error);
+        }
+    }
 }

--- a/services/OneCampaignMonitor_SubscribersService.php
+++ b/services/OneCampaignMonitor_SubscribersService.php
@@ -71,6 +71,12 @@ class OneCampaignMonitor_SubscribersService extends OneCampaignMonitor_BaseServi
 
         if ($mergeMultiFields) {
             $result = $connection->get($email);
+            
+            $error = null;
+            if (!$this->response($result, $error)) {
+                throw new Exception($error);
+            }
+
             $existingSubscriber = $result->response;
 
             // Count the number of occurances of custom field to know 

--- a/services/OneCampaignMonitor_SubscribersService.php
+++ b/services/OneCampaignMonitor_SubscribersService.php
@@ -102,32 +102,14 @@ class OneCampaignMonitor_SubscribersService extends OneCampaignMonitor_BaseServi
 
             $existingSubscriber = $result->response;
 
-            // Count the number of occurances of custom field to know 
-            // which is a Multi-Valued Select Many field
-            $fieldOccurances = [];
             foreach ($existingSubscriber->CustomFields as $existingField) {
-                if (array_key_exists($existingField->Key, $fieldOccurances)) {
-                    $fieldOccurances[$existingField->Key]++;
-                } else {
-                    $fieldOccurances[$existingField->Key] = 1;
-                }
+                $subscriber['CustomFields'][] = [
+                    'Key' => $existingField->Key,
+                    'Value' => $existingField->Value
+                ];
             }
-
-            // For any Multi-Valued Select Many field, make sure to append the 
-            // existing field values
-            foreach($fieldOccurances as $key => $value) {
-                if ($value > 1) {
-                    foreach($existingSubscriber->CustomFields as $existingField) {
-                        if ($existingField->Key == $key) {
-                            $subscriber['CustomFields'][] = $existingField;
-                        }
-                    }
-                }
-            }
-        } else {
-            $subscriber['CustomFields'] = $parsedCustomFields;
         }
-        
+
         $result = $connection->update($email, $subscriber);
 
         $error = null;

--- a/services/OneCampaignMonitor_SubscribersService.php
+++ b/services/OneCampaignMonitor_SubscribersService.php
@@ -40,6 +40,29 @@ class OneCampaignMonitor_SubscribersService extends OneCampaignMonitor_BaseServi
     }
 
     /**
+     * Determines is a subscriber exists in a list
+     * @param  $listId
+     * @param  $email
+     * @return  Boolean
+     * @throws Exception
+     */
+    public function exists($listId, $email) {
+        if (!$listId) {
+            throw new Exception('List ID is required');
+        }
+        if (!$email) {
+            throw new Exception('Please provide a valid email address');
+        }
+
+        $connection = new \CS_REST_Subscribers($listId, $this->auth());
+
+        $result = $connection->get($email);
+            
+        $error = null;
+        return $this->response($result, $error);
+    }
+
+    /**
      * Updates a subscriber in a list
      * @param  $listId
      * @param  $email


### PR DESCRIPTION
- Adds a service method to update a user in a list
- Adds a service method to check if a user exists in a list
- Includes new console commands to use/test these features at the CLI

## Acceptance Testing
1. Install this plugin (Use ODC Testing API key)
2. Login to Campaign Monitor (ODC Testing)
3. Run each of these commands and check the tests

```
php ./craft/app/etc/console/yiic onecampaignmonitorsubscribers add --listId="a8ba3ee942afdbdc83bbb51e49ba3c0b" --email="pr-testing@onedesigncompany.com" --name="Name" --resubscribe=1 --customFields='[{"Key":"Subscriptions","Value":"FN-SUB33"}]'
```
- [x] I see pr-testing@onedesigncompany.com in Campaign Monitor
- [x] I see custom "Subscriptions" field "FN-SUB33"

```
php ./craft/app/etc/console/yiic onecampaignmonitorsubscribers update --listId="a8ba3ee942afdbdc83bbb51e49ba3c0b" --email="pr-testing@onedesigncompany.com" --name="A Full Name" --resubscribe=1 --customFields='[{"Key":"Subscriptions","Value":"FN-SUB33-Renewal"}]' --merge=1
```
- [x] I see the name updated for the subscriber
- [x] I see custom "Subscription" fields "FN-SUB33" and "FN-SUB33-Renewal"


```
php ./craft/app/etc/console/yiic onecampaignmonitorsubscribers update --listId="a8ba3ee942afdbdc83bbb51e49ba3c0b" --email="pr-testing@onedesigncompany.com" --customFields='[{"Key":"Subscriptions","Value":"FNC-SUB34"}]' --merge=0
```
- [x] I see the only "FNC-SUB34" in the custom "Subscription" field


```
php ./craft/app/etc/console/yiic onecampaignmonitorsubscribers exists --listId="a8ba3ee942afdbdc83bbb51e49ba3c0b" --email="pr-testing@onedesigncompany.com"
```
- [x] I see "Subscriber exists in this list." in the output


```
php ./craft/app/etc/console/yiic onecampaignmonitorsubscribers exists --listId="a8ba3ee942afdbdc83bbb51e49ba3c0b" --email="nonone@onedesigncompany.com"
```
- [x] I see "Subscriber does not exist in the list." in the output