### PR TITLE
Feature/ensure custom fields

### DIFF
--- a/consolecommands/OneCampaignMonitorListsCommand.php
+++ b/consolecommands/OneCampaignMonitorListsCommand.php
@@ -1,0 +1,33 @@
+<?php
+namespace Craft;
+
+class OneCampaignMonitorListsCommand extends BaseCommand {
+
+    /**
+     * Ensures an array of custom fields exists for a given list
+     * Usage:
+     *   php ./craft/app/etc/console/yiic onecampaignmonitorlists ensureCustomFieldsExist \
+     *       --listId="asdf..." \
+     *       --customFields='[{"Key":"City","Value":"Chicago"}]'
+     */
+    public function actionEnsureCustomFieldsExist($listId, $customFields='[]') {
+        $customFields = $this->_decodeCustomFields($customFields);
+        craft()->oneCampaignMonitor_lists->ensureCustomFieldsExist($listId, $customFields);
+    }
+
+    /**
+     * Decodes the customFields input option
+     * @param  String $customFields JSON array of key/value objects
+     * @return Array
+     */
+    private function _decodeCustomFields($customFields) {
+        $decoded = json_decode($customFields, true);
+
+        if (!is_array($decoded)) {
+            throw new Exception('customFields must be specified as a JSON array of key/value objects');
+        }
+
+        return $decoded;
+    }
+
+}

--- a/services/OneCampaignMonitor_BaseService.php
+++ b/services/OneCampaignMonitor_BaseService.php
@@ -18,7 +18,11 @@ class OneCampaignMonitor_BaseService extends BaseApplicationComponent {
     protected function parseCustomFields($fields) {
         $data = array();
         foreach ($fields as $key => $value) {
-            $data[] = ['Key' => $key, 'Value' => $value];
+            if (is_array($value) && array_key_exists('Key', $value) && array_key_exists('Value', $value) ) {
+                $data[] = $value;
+            } else {
+                $data[] = ['Key' => $key, 'Value' => $value];
+            }
         }
         return $data;
     }

--- a/services/OneCampaignMonitor_ListsService.php
+++ b/services/OneCampaignMonitor_ListsService.php
@@ -1,0 +1,100 @@
+<?php
+namespace Craft;
+
+require_once CRAFT_BASE_PATH . '../vendor/campaignmonitor/createsend-php/csrest_lists.php';
+
+class OneCampaignMonitor_ListsService extends OneCampaignMonitor_BaseService {
+
+    /**
+     * Ensures custom fields already exists or creates them. This also creates
+     * Multi-Valued Select Many options if necessary.
+     * @param  String $listId
+     * @param  Array $customFields
+     * @throws Exception
+     */
+    public function ensureCustomFieldsExist(
+        $listId, $customFields, $defaultDataType='MultiSelectMany', $visibleInPreferenceCenter=false
+    ){
+        if (!$listId) {
+            throw new Exception('List ID is required');
+        }
+        if (empty($customFields)) {
+            throw new Exception('Custom fields are required');
+        }
+
+        $connection = new \CS_REST_Lists($listId, $this->auth());
+
+        $result = $connection->get_custom_fields();
+        $error = null;
+        if (!$this->response($result, $error)) {
+            throw new Exception($error);
+        }
+
+        $existingCustomFields = $result->response;
+
+        $parsedCustomFields = $this->parseCustomFields($customFields);
+
+        // Find all fields that don't already exist
+        $fieldsToAdd = [];
+        $optionsToAdd = [];
+        foreach ($parsedCustomFields as $checkField) {
+            $fieldExists = false;
+            $optionExists = false;
+            foreach ($existingCustomFields as $existingField) {
+                // Campaign Monitor encloses keys in [] in this response
+                if ('[' . $checkField['Key'] . ']' == $existingField->Key) {
+                    $fieldExists = true;
+
+                    // Check that the option exists for MultiSelect fields
+                    if ($existingField->DataType == 'MultiSelectOne' || $existingField->DataType == 'MultiSelectMany') {
+                        foreach ($existingField->FieldOptions as $option) {
+                            if ($option == $checkField['Value']) {
+                                $optionExists = true;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (!$fieldExists) {
+                $fieldsToAdd[$checkField['Key']] = $checkField;
+            }
+
+            if (!$optionExists) {
+                $optionsToAdd[$checkField['Key']][] = $checkField['Value'];
+            }
+        }
+
+        // Add any fields that don't yet exist
+        foreach ($fieldsToAdd as $field) {
+            if (array_key_exists($field['Key'], $optionsToAdd)) {
+                $options = $optionsToAdd[$field['Key']];
+                unset($optionsToAdd[$field['Key']]);
+            } else {
+                $options = [];
+            }
+
+            $result = $connection->create_custom_field([
+                'FieldName' => $field['Key'],
+                'DataType' => $defaultDataType,
+                'Options' =>  $options,
+                'VisibleInPreferenceCenter' => $visibleInPreferenceCenter,
+            ]);
+
+            $error = null;
+            if (!$this->response($result, $error)) {
+                throw new Exception($error);
+            }
+        }
+
+        // Add any options we haven't already added (field existed but not options)
+        foreach ($optionsToAdd as $key => $options) {
+            $result = $connection->update_field_options('['.$key.']', $options, true);
+
+            $error = null;
+            if (!$this->response($result, $error)) {
+                throw new Exception($error);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Adds a service method to create and add custom field options to lists

This is meant to be helpful in the case you're dynamically adding options and custom fields to lists. This service allows you to handle that programmatically, rather than needing to do it by hand via Campaign Monitor.

## Acceptance Testing
1. Install this plugin (Use ODC Testing API key)
2. Login to Campaign Monitor
3. Run the CLI command below and check the tests

```
php ./craft/app/etc/console/yiic onecampaignmonitorlists ensureCustomFieldsExist --listId="a8ba3ee942afdbdc83bbb51e49ba3c0b" --customFields='[{"Key":"Country","Value":"USA"}]'
```
- [x] I can see "Country" in the [custom fields](https://onedesigncompany1.createsend.com/subscribers/customfieldsettings/DED04BD6ED50001E) with "USA" as an option